### PR TITLE
Update to egui@0.28

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ include = ["../LICENSE-APACHE", "../LICENSE-MIT", "**/*.rs", "Cargo.toml"]
 
 [dependencies]
 bytemuck = "1.9"
-egui = { version = "0.27", features = ["bytemuck"] }
+egui = { version = "0.28", features = ["bytemuck"] }
 miniquad = { version = "=0.4.0" }
 quad-url = "0.1"
 
@@ -31,7 +31,7 @@ quad-rand = "0.2.1"
 copypasta = "0.8.1"
 
 [dev-dependencies]
-egui_demo_lib = { version = "0.27", default-features = false }
+egui_demo_lib = { version = "0.28", default-features = false }
 glam = "0.22.0"
 
 [profile.release]


### PR DESCRIPTION
Updates to new version: https://github.com/emilk/egui/releases/tag/0.28.0